### PR TITLE
Add configurable host URL - PMT #109816

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 2017-01-27  Nik Nyby  <nnyby@columbia.edu>
 
-	* The host url is nor configurable.
+	* The host url is now configurable.
 
 2016-05-13  Nik Nyby  <nnyby@columbia.edu>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-01-27  Nik Nyby  <nnyby@columbia.edu>
+
+	* The host url is nor configurable.
+
 2016-05-13  Nik Nyby  <nnyby@columbia.edu>
 
 	* Fixed Go To Collection link.

--- a/Mediathread.safariextension/Info.plist
+++ b/Mediathread.safariextension/Info.plist
@@ -5,7 +5,7 @@
 	<key>Author</key>
 	<string>Columbia University's Center for Teaching and Learning</string>
 	<key>Builder Version</key>
-	<string>12602.3.12.0.1</string>
+	<string>12602.4.8</string>
 	<key>CFBundleDisplayName</key>
 	<string>Mediathread</string>
 	<key>CFBundleIdentifier</key>

--- a/Mediathread.safariextension/Settings.plist
+++ b/Mediathread.safariextension/Settings.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<dict>
+		<key>DefaultValue</key>
+		<string>https://mediathread.ccnmtl.columbia.edu</string>
+		<key>Key</key>
+		<string>hostUrl</string>
+		<key>Title</key>
+		<string>Mediathread URL</string>
+		<key>Type</key>
+		<string>TextField</string>
+	</dict>
+</array>
+</plist>

--- a/Mediathread.safariextension/injected/listener.js
+++ b/Mediathread.safariextension/injected/listener.js
@@ -1,8 +1,10 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 
-var hostUrl = 'https://mediathread.ccnmtl.columbia.edu/';
+var startCollect = function(hostUrl) {
+    if (typeof hostUrl === 'undefined' || !hostUrl) {
+        hostUrl = 'https://mediathread.ccnmtl.columbia.edu';
+    }
 
-var startCollect = function() {
     $.ajax({
         url: hostUrl + '/accounts/is_logged_in/',
         dataType: 'json',
@@ -45,11 +47,12 @@ var startCollect = function() {
  */
 var handleMessage = function(msgEvent) {
     var messageName = msgEvent.name;
+    var messageData = msgEvent.message;
     // msgEvent.message is the message data, but it's
     // not being used.
 
     if (messageName === 'mediathread-collect') {
-        startCollect();
+        startCollect(messageData);
     }
 };
 

--- a/Mediathread.safariextension/src/global.js
+++ b/Mediathread.safariextension/src/global.js
@@ -3,8 +3,9 @@ var itemArray = safari.extension.toolbarItems;
 var buttonClicked = function(event) {
     if (event.command === 'mediathread') {
         // Send a "collect" message to the content script
+        var hostUrl = safari.extension.settings.hostUrl;
         safari.application.activeBrowserWindow.activeTab.page.dispatchMessage(
-            'mediathread-collect', null);
+            'mediathread-collect', hostUrl);
     }
 };
 


### PR DESCRIPTION
This turned out to be simpler than I anticipated, because the Safari
Extension builder has built-in functionality to accommodate for this -
the UI comes automatically.